### PR TITLE
Launch native Linux KeeperFX directly instead of via Wine

### DIFF
--- a/Autoload/Settings.gd
+++ b/Autoload/Settings.gd
@@ -154,13 +154,18 @@ func cfg_remove_setting(setting):
 func auto_detect_executable():
 	var directories = [OS.get_executable_path().get_base_dir(), OS.get_executable_path().get_base_dir().get_base_dir()]
 	var executables = [["keeperfx", "exe"], ["keeper", "exe"]]
-	
+
 	for directory in directories:
+		# Native Linux KeeperFX is an extension-less "keeperfx" binary; detect it first.
+		if OS.get_name() == "X11":
+			var nativePath = directory.plus_file("keeperfx")
+			if File.new().file_exists(nativePath):
+				return nativePath
 		for executable in executables:
 			var foundPath = Utils.case_insensitive_file(directory, executable[0], executable[1])
 			if foundPath != "":
 				return foundPath
-	
+
 	return ""
 
 

--- a/Scenes/ChooseDkExe.gd
+++ b/Scenes/ChooseDkExe.gd
@@ -5,6 +5,12 @@ onready var oMessage = Nodelist.list["oMessage"]
 onready var oKeeperFXDetection = Nodelist.list["oKeeperFXDetection"]
 onready var oMapBrowser = Nodelist.list["oMapBrowser"]
 
+func _ready():
+	# On Linux the native KeeperFX binary ("keeperfx") has no .exe extension, so the
+	# scene's "*.exe" filter would hide it. Show all files so it can be selected.
+	if OS.get_name() == "X11":
+		clear_filters()
+
 func _on_ChooseDkExe_file_selected(path):
 	Settings.set_setting("executable_path", path) # Do this first so keeperfx_is_installed() works
 	if oGame.keeperfx_is_installed() == false:

--- a/Scenes/Game.gd
+++ b/Scenes/Game.gd
@@ -33,7 +33,7 @@ const KEEPERFX_MAP_ROOTS = ["levels", "multiplayer", "campgns"]
 
 func keeperfx_is_installed():
 	var path = EXECUTABLE_PATH.get_file().to_lower()
-	if path == "keeperfx.exe" or path == "keeperfx_hvlog.exe":
+	if path == "keeperfx.exe" or path == "keeperfx_hvlog.exe" or path == "keeperfx":
 		return true
 	else:
 		return false
@@ -152,8 +152,14 @@ func cmdline(mapPath, packetLoad):
 		"X11":
 			constructString += "cd "
 			constructString += "'" + GAME_DIRECTORY + "'"
-			constructString += " && wine "
-			constructString += "'" + EXECUTABLE_PATH.get_file() + "'"
+			constructString += " && "
+			# Native Linux KeeperFX runs directly (no Wine). Only fall back to Wine
+			# for an actual Windows .exe (e.g. running the Windows build under Wine).
+			if EXECUTABLE_PATH.get_extension().to_lower() == "exe":
+				constructString += "wine "
+				constructString += "'" + EXECUTABLE_PATH.get_file() + "'"
+			else:
+				constructString += "'./" + EXECUTABLE_PATH.get_file() + "'"
 	
 	# Delete -level xxx and -campaign xxx from the command line
 	var arrayOfWords = constructString.split(" ")


### PR DESCRIPTION
## Native Linux launch for KeeperFX (no Wine)

KeeperFX now ships **native Linux builds** — the game executable is `keeperfx` with no `.exe` extension. On Linux, Unearth currently always wraps the game in **Wine** and only recognizes `keeperfx.exe`, so **Save & Play fails against a native KeeperFX install**. This PR makes Save & Play work natively on Linux.

All changes are guarded so **Windows behavior is unchanged**:

- **`Game.gd` `keeperfx_is_installed()`** — also accept an extension-less `keeperfx`.
- **`Game.gd` `cmdline()`** — on X11, run the executable directly when it is not a `.exe` (native binary); keep Wine for an actual `.exe` (Windows build under Wine).
- **`Settings.gd` `auto_detect_executable()`** — detect a native `keeperfx` binary (no extension) in addition to `keeperfx.exe` / `keeper.exe`.
- **`ChooseDkExe.gd`** — on X11, clear the `*.exe`-only file-dialog filter so the native binary is selectable.

### Testing
On Linux against a native KeeperFX build: auto-detect finds the native `keeperfx`, the editor opens straight to editing (no “select executable” nag), and `cmdline()` produces `cd '<dir>' && './keeperfx' -level N -campaign X` — verified that command launches the native game directly, no Wine.